### PR TITLE
FIX: DPT2 am Ausgang sendet wieder korrekte Werte

### DIFF
--- a/doc/Applikationsbeschreibung-Logik.md
+++ b/doc/Applikationsbeschreibung-Logik.md
@@ -83,6 +83,10 @@ Eine Übersicht über die verfügbaren Konfigurationsseiten und Links zur jeweil
 
 Im folgenden werden Änderungen an dem Dokument erfasst, damit man nicht immer das Gesamtdokument lesen muss, um Neuerungen zu erfahren.
 
+24.08.2025: Firmware 3.7.2, Applikation 3.7:
+
+* FIX: DPT2 am Ausgang sendet wieder korrekte Werte, ist wohl in der Vergangenheit durch eine Änderung am KNX-Stack kaputt gegangen und wurde erst jetzt gemerkt.
+
 16.06.2025: Firmware 3.7, Applikation 3.7:
 
 * NEU: Ausgangs-KO eines Logikkanals kann jetzt manuell ausgeblendet werden. Der automatische Ein-/Ausblendalgorithmus wurde entfernt, weil er nicht alle gewünschten Fälle abdecken konnte. Nach einem Update müssen unerwünschte KO, die früher automatisch ausgeblendet worden sind, manuell ausgeblendet  werden. Dies ändert nichts an der Funktionalität der Logik, es geht nur um die Übersichtlichkeit in der ETS.

--- a/library.json
+++ b/library.json
@@ -1,6 +1,6 @@
 {
     "name": "OFM-LogicModule",
-    "version": "3.7.1",
+    "version": "3.7.2",
     "description": "Logic module for the knx stack, can be embedded in an ETS application",
     "homepage": "https://openknx.de",
     "authors": {

--- a/src/LogicChannel.cpp
+++ b/src/LogicChannel.cpp
@@ -255,7 +255,7 @@ GroupObject *LogicChannel::getKo(uint8_t iIOIndex)
     return lKo;
 }
 
-Dpt &LogicChannel::getKoDPT(uint8_t iIOIndex)
+Dpt &LogicChannel::getKoDPT(uint8_t iIOIndex, bool iHandleDpt2asByte /* = false */)
 {
     uint8_t lDpt;
     switch (iIOIndex)
@@ -273,6 +273,8 @@ Dpt &LogicChannel::getKoDPT(uint8_t iIOIndex)
             lDpt = 0;
             break;
     }
+    if (iHandleDpt2asByte && lDpt == VAL_DPT_2) // DPT2
+        lDpt = VAL_DPT_5; // handle DPT2 as DPT5 for internal processing
     return getDPT(lDpt);
 }
 
@@ -322,10 +324,11 @@ void LogicChannel::knxWrite(uint8_t iIOIndex, KNXValue &iValue, bool iOn, bool i
     bool lSendOnChanged = ParamLOG_fOSendOnChange;
     GroupObject *lKo = getKo(iIOIndex);
     bool lChanged = false;
+    Dpt &lDpt = getKoDPT(iIOIndex, true);
     if (lSendOnChanged)
-        lChanged = lKo->valueNoSendCompare(iValue, getKoDPT(iIOIndex));
+        lChanged = lKo->valueNoSendCompare(iValue, lDpt);
     else
-        lKo->value(iValue, getKoDPT(iIOIndex));
+        lKo->value(iValue, lDpt);
     if (lChanged)
         lKo->objectWritten();
     if (iAdditional)
@@ -336,9 +339,9 @@ void LogicChannel::knxWrite(uint8_t iIOIndex, KNXValue &iValue, bool iOn, bool i
             lKo = &knx.getGroupObject(lKoNumber);
             lChanged = false;
             if (lSendOnChanged)
-                lChanged = lKo->valueNoSendCompare(iValue, getKoDPT(iIOIndex));
+                lChanged = lKo->valueNoSendCompare(iValue, lDpt);
             else
-                lKo->value(iValue, getKoDPT(iIOIndex));
+                lKo->value(iValue, lDpt);
             if (lChanged)
                 lKo->objectWritten();
         }

--- a/src/LogicChannel.h
+++ b/src/LogicChannel.h
@@ -233,7 +233,7 @@ class LogicChannel : public OpenKNX::Channel
     uint8_t *getStringParam(uint16_t iParamIndex);
     uint32_t getTimeDelayParam(uint16_t iParamIndex, bool iAsSeconds = false);
     GroupObject *getKo(uint8_t iIOIndex);
-    Dpt &getKoDPT(uint8_t iIOIndex);
+    Dpt &getKoDPT(uint8_t iIOIndex, bool iHandleDpt2asByte = false);
     uint16_t checkAdditionalWrite(bool iOn);
     void knxWrite(uint8_t iIOIndex, KNXValue &iValue, bool iOn, bool iAdditional = true);
     void knxWriteBool(uint8_t iIOIndex, bool iValue, bool iOn);


### PR DESCRIPTION
Ist wohl in der Vergangenheit durch eine Änderung am KNX-Stack kaputt gegangen und wurde erst jetzt gemerkt.