### PR TITLE
Use OpenKNX Default Log-Prefix for Channels (Remove Old Implementation)

### DIFF
--- a/src/LogicChannel.cpp
+++ b/src/LogicChannel.cpp
@@ -30,10 +30,6 @@ LogicChannel::LogicChannel(uint8_t iChannelNumber)
     pTriggerIO = 0;
     pCurrentIn = BIT_INITIAL_GATE;
     pCurrentOut = BIT_OUTPUT_INITIAL; // tri-state output, at the beginning we are undefined
-    pLogPrefix[0] = 'C';
-    pLogPrefix[1] = '0' + (iChannelNumber + 1) / 10;
-    pLogPrefix[2] = '0' + (iChannelNumber + 1) % 10;
-    pLogPrefix[3] = 0;
 }
 
 LogicChannel::~LogicChannel()
@@ -43,11 +39,6 @@ LogicChannel::~LogicChannel()
 /******************************
  * Debug helper
  * ***************************/
-
-const std::string LogicChannel::logPrefix()
-{
-    return std::string(pLogPrefix);
-}
 
 #if LOGIC_TRACE
 char *LogicChannel::logTimeBase(uint16_t iParamIndex)

--- a/src/LogicChannel.h
+++ b/src/LogicChannel.h
@@ -225,8 +225,6 @@ class LogicChannel : public OpenKNX::Channel
     static TimerRestore &sTimerRestore;
 
     // instance
-    char pLogPrefix[4];
-    virtual const std::string logPrefix() override;
     /* Runtime information per channel */
     uint8_t pTriggerIO;        // Bitfield: Which input (0-3) triggered processing, Bit 4-7 are previous input (currently just internal inputs evaluated)
     uint8_t pValidActiveIO;    // Bitfield: validity flags for input (0-3) values and active inputs (4-7)


### PR DESCRIPTION
@mumpf soweit für mich zu erkennen, wird dieser Teil der Implementierung nicht mehr benötigt, da die Kanal-Nummer durch die die OpenKNX-Channel-Basisimplementierung bereitgestellt wird.

Bitte da selbst noch mal kritisch überprüfen auf unerwartete Nebeneffekte.