### PR TITLE
Fix MIN/MAX with previous output for equal inputs

### DIFF
--- a/src/LogicFunction.cpp
+++ b/src/LogicFunction.cpp
@@ -165,22 +165,28 @@ LogicValue LogicFunction::nativeSubtractE1MinusE2(uint8_t _channelIndex, PT_Logi
 
 LogicValue LogicFunction::nativeMinimumA(uint8_t _channelIndex, PT_LogicDpt DptE1, LogicValue E1, PT_LogicDpt DptE2, LogicValue E2, PT_LogicDpt *DptOut, LogicValue iOld)
 {
-    if (E1 < E2 && E1 < iOld)
-        return E1;
-    else if (E2 < E1 && E2 < iOld)
-        return E2;
-    else
-        return iOld;
+    LogicValue lResult = iOld;
+
+    if (E1 < lResult)
+        lResult = E1;
+
+    if (E2 < lResult)
+        lResult = E2;
+
+    return lResult;
 }
 
 LogicValue LogicFunction::nativeMaximumA(uint8_t _channelIndex, PT_LogicDpt DptE1, LogicValue E1, PT_LogicDpt DptE2, LogicValue E2, PT_LogicDpt *DptOut, LogicValue iOld)
 {
-    if (E1 > E2 && E1 > iOld)
-        return E1;
-    else if (E2 > E1 && E2 > iOld)
-        return E2;
-    else
-        return iOld;
+    LogicValue lResult = iOld;
+
+    if (E1 > lResult)
+        lResult = E1;
+
+    if (E2 > lResult)
+        lResult = E2;
+
+    return lResult;
 }
 
 LogicValue LogicFunction::nativeLShiftE1(uint8_t _channelIndex, PT_LogicDpt DptE1, LogicValue E1, PT_LogicDpt DptE2, LogicValue E2, PT_LogicDpt *DptOut, LogicValue iOld)


### PR DESCRIPTION
## Beschreibung

Bei `MIN(E1,E2,A)` und `MAX(E1,E2,A)` gab es einen Fehler, wenn `E1` und `E2` gleich waren.

Beispiel:

```text
E1 = 10
E2 = 10
A  = 0
```

Bei `MAX(E1,E2,A)` kam bisher fälschlicherweise `0` heraus.

Richtig ist:

```text
10
```

Der Fehler wurde behoben.  
`E1` und `E2` werden jetzt einzeln mit dem bisherigen Wert `A` verglichen.

Damit funktionieren auch gleiche Eingangswerte korrekt.

Getestet wurde zum Beispiel:

```text
E1=10, E2=10, A=0  -> 10
E1=20, E2=10, A=10 -> 20
E1=10, E2=10, A=20 -> 20
```

Der gleiche Fehler wurde auch bei `MIN(E1,E2,A)` behoben.
