### PR TITLE
Fix B29 and B30 formula lookup

### DIFF
--- a/src/LogicFunction.cpp
+++ b/src/LogicFunction.cpp
@@ -319,7 +319,6 @@ LogicValue LogicFunction::callFunction(uint8_t _channelIndex, uint8_t iId, PT_Lo
 }
 
 // new user formulas
-const uint8_t LogicFunction::sVarsSize = 37;
 // bind variables and functions to parser
 te_variable LogicFunction::sVars[] = {
     {"e1", &e1},
@@ -361,6 +360,9 @@ te_variable LogicFunction::sVars[] = {
     {"b28", (double *)myB28, TE_FUNCTION3},
     {"b29", (double *)myB29, TE_FUNCTION3},
     {"b30", (double *)myB30, TE_FUNCTION3}};
+
+const uint8_t LogicFunction::sVarsSize =
+    sizeof(LogicFunction::sVars) / sizeof(LogicFunction::sVars[0]);
 
 double LogicFunction::myIf(double iCondition, double iTrue, double iFalse)
 {


### PR DESCRIPTION
Die Benutzerformeln `B29` und `B30` konnten bisher nicht aus anderen Benutzerformeln aufgerufen werden.

Es war eine fest eingetragene Anzahl von `37` Einträgen für den Formel-Parser. Tatsächlich gibt es `39` Einträge.

Dadurch wurden `b29()` und `b30()` nicht berücksichtigt.

Die Anzahl wird jetzt automatisch aus dem vorhandenen Array ermittelt.

Getestet wurde zum Beispiel mit:

```text
B29 = 29
B30 = 30
B28 = b29(0,0,0) + b30(0,0,0)
```

Ergebnis:

```text
59
```
