### PR TITLE
Allow external input reference to last KO

### DIFF
--- a/src/LogicChannel.cpp
+++ b/src/LogicChannel.cpp
@@ -232,14 +232,14 @@ GroupObject *LogicChannel::getKo(uint8_t iIOIndex)
     switch (lAbsRel)
     {
         case PT_KORelInput::Absolute:
-            if (lExternalAccess > 0 && lExternalAccess < MAIN_MaxKoNumber)
+            if (lExternalAccess > 0 && lExternalAccess <= MAIN_MaxKoNumber)
                 lKoNumber = lExternalAccess;
             break;
 
         case PT_KORelInput::Relative:
         {
             int16_t lNewKoNumber = lKoNumber + lExternalAccess;
-            if (lNewKoNumber > 0 && lNewKoNumber < MAIN_MaxKoNumber)
+            if (lNewKoNumber > 0 && lNewKoNumber <= MAIN_MaxKoNumber)
                 lKoNumber = lNewKoNumber;
         }
         break;


### PR DESCRIPTION
## Beschreibung

Beim Lesen eines externen Eingangs-KO konnte das letzte gültige KO bisher nicht verwendet werden.

Die Prüfung war so aufgebaut:

```cpp
< MAIN_MaxKoNumber
```

Damit wurde `MAIN_MaxKoNumber` selbst ausgeschlossen.

Die Prüfung wurde auf:

```cpp
<= MAIN_MaxKoNumber
```

geändert.

Das gilt sowohl für absolute als auch für relative KO-Verweise.

Damit kann jetzt auch das letzte gültige KO verwendet werden.
