### PR TITLE
Fix delta comparison input activation

### DIFF
--- a/src/LogicChannel.cpp
+++ b/src/LogicChannel.cpp
@@ -849,7 +849,7 @@ bool LogicChannel::isInputActive(uint8_t iIOIndex)
     {
         // input might be also activated by a delta input converter, means from the other input
         PT_InputConv lConverter = (iIOIndex == IO_Input2) ? ParamLOG_fE1Convert : ParamLOG_fE2Convert;
-        lIsActive = (lConverter < PT_InputConv::Einzelwerte) && (lIsActive & 1);
+        lIsActive = (lConverter < PT_InputConv::Einzelwerte) && (((uint8_t)lConverter & 1) != 0);
     }
     return (lIsActive > 0);
 }


### PR DESCRIPTION
Bei `Differenzintervall` und `Differenzhysterese` kann der jeweils andere Eingang als Vergleichswert verwendet werden, obwohl dieser Eingang selbst auf `inaktiv` steht.

In `LogicChannel::isInputActive()` wurde in diesem Fall jedoch geprüft

```cpp
(lIsActive & 1)
```

Dieser Code steht innerhalb von `if (lIsActive == 0)`, daher kann die Bedingung dort niemals wahr werden.

Geprüft werden muss stattdessen der verwendete Converter

```cpp
((uint8_t)lConverter & 1)
```

Dadurch wird der inaktive Vergleichseingang für `Differenzintervall` bzw. `Differenzhysterese` korrekt als Hilfseingang behandelt und Änderungen auf einem absoluten/relativen externen KO lösen wieder eine Neuberechnung aus.

vor dem Fix:

- E1 aktiv, DPT9
- E1 verwendet Differenzhysterese
- E2 als normaler Eingang inaktiv
- E2-Differenzwert über absolutes externes KO
- Ausschaltwert: `-10 K`
- Einschaltwert: `+10 K`

```text
E1 = 20 K
E2 = 15 K
E2 -> 5 K
```

Obwohl die Differenz danach +15 K beträgt, reagierte der Ausgang nicht.

Erst nach einer zusätzlichen Änderung von E1 wurde mit dem bereits empfangenen neuen E2-Wert neu berechnet.

Jetzt:

E1 blieb konstant auf `20 K`:

```text
E2 = 35 K -> Differenz -15 K -> Q sofort AUS
E2 = 5 K  -> Differenz +15 K -> Q sofort EIN
```
