### PR TITLE
Fix nested user formula context

### DIFF
--- a/src/LogicFunction.cpp
+++ b/src/LogicFunction.cpp
@@ -582,6 +582,11 @@ LogicValue LogicFunction::callUserFormula(uint8_t iFormulaIndex, double iE1, dou
     double lResult = 0;
     bool lFailed = false;
 
+    // Preserve caller context for nested B-formula calls.
+    double lPreviousE1 = e1;
+    double lPreviousE2 = e2;
+    double lPreviousOut = out;
+
     sRecursionCounter++;
     if (sRecursionCounter <= NUM_RECURSION_DEPTH)
     {
@@ -619,6 +624,12 @@ LogicValue LogicFunction::callUserFormula(uint8_t iFormulaIndex, double iE1, dou
         lFailed = true;
     }
     sRecursionCounter--;
+
+    // Restore the variables of the caller after a nested formula call.
+    e1 = lPreviousE1;
+    e2 = lPreviousE2;
+    out = lPreviousOut;
+
     if (lFailed)
         return LogicValue(NAN);
     else


### PR DESCRIPTION
Verschachtelte Benutzerformeln überschreiben E1, E2 und A

Benutzerformeln können andere Benutzerformeln über `B1(...)` bis `B30(...)` aufrufen.

Dabei werden die Werte für `E1`, `E2` und `A` intern gemeinsam verwendet. Ruft eine Formel eine weitere B-Formel auf, überschreibt die innere Formel diese Werte.

Nach dem Rücksprung zur äußeren Formel stehen dann nicht mehr die ursprünglichen Werte zur Verfügung.

Dadurch hängt das Ergebnis davon ab, an welcher Stelle der verschachtelte B-Aufruf in der Formel steht.

Beispiel:

Verwendete Formeln:

```text
B1 = E1+E2
B2 = E1+B1(1,2,A)
B3 = B1(1,2,A)+E1
```

Mit:

```text
E1 = 10
```

müssen B2 und B3 beide dasselbe Ergebnis liefern:

```text
B1(1,2,A) = 3

B2 = 10 + 3 = 13
B3 = 3 + 10 = 13
```

Erhalten:

```text
B2 = 13
B3 = 4
```

Der verschachtelte Aufruf `B1(1,2,A)` hatte den Wert von `E1` der äußeren Formel von `10` auf `1` überschrieben.

Dadurch wurde B3 tatsächlich so berechnet:

```text
3 + 1 = 4
```

Vor dem Aufruf einer Benutzerformel werden die aktuellen Werte von `E1`, `E2` und `A` gesichert.
Nach der Auswertung der Formel werden diese Werte wiederhergestellt.
Damit kann eine verschachtelte B-Formel den Kontext der aufrufenden Formel nicht mehr verändern.


Der gleiche Test nach dem Fix:

```text
B2 = 13
B3 = 13
```





